### PR TITLE
refa: improve helm chart for openshift

### DIFF
--- a/charts/steadybit-extension-container/Chart.yaml
+++ b/charts/steadybit-extension-container/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-container
 description: Steadybit container extension Helm chart for Kubernetes.
-version: 1.1.32
+version: 1.1.33
 appVersion: v1.3.30
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-container/templates/_helpers.tpl
+++ b/charts/steadybit-extension-container/templates/_helpers.tpl
@@ -40,3 +40,19 @@ containerRuntime.volumes will render pod volumes (without indentation) for the s
     path: "{{ $runtimeValues.runcRoot }}"
     type: Directory
 {{- end -}}
+
+
+{{- /*
+will omit attribute from the passed in object depending on the KubeVersion
+*/}}
+{{- define "omitForKuberVersion" -}}
+{{- $top := index . 0 -}}
+{{- $versionConstraint := index . 1 -}}
+{{- $dict := index . 2 -}}
+{{- $toOmit := index . 3 -}}
+{{- if semverCompare $versionConstraint $top.Capabilities.KubeVersion.Version -}}
+{{- $dict := omit $dict $toOmit -}}
+{{- end -}}
+{{- $dict | toYaml -}}
+{{- end -}}
+

--- a/charts/steadybit-extension-container/templates/daemonset.yaml
+++ b/charts/steadybit-extension-container/templates/daemonset.yaml
@@ -117,19 +117,10 @@ spec:
             httpGet:
               path: /health/readiness
               port: {{ .Values.containerPorts.health }}
+          {{- with (include "omitForKuberVersion" (list . "<1.30-0" .Values.containerSecurityContext "appArmorProfile" )) }}
           securityContext:
-            {{- if semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version}}
-            appArmorProfile:
-              type: Unconfined
-            {{- end }}
-            seccompProfile:
-              type: Unconfined
-            capabilities:
-              add: {{ toJson .Values.securityContext.capabilities.add }}
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 10000
-            runAsGroup: 10000
+          {{- . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: tmp-dir
           emptyDir: {}

--- a/charts/steadybit-extension-container/templates/scc-clusterrole.yaml
+++ b/charts/steadybit-extension-container/templates/scc-clusterrole.yaml
@@ -1,0 +1,15 @@
+{{- if or .Values.securityContextConstraint.create (and (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") (eq .Values.securityContextConstraint.create nil)) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "system:openshift:scc:{{ .Values.securityContextConstraint.name }}"
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - {{ .Values.securityContextConstraint.name }}
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+{{- end -}}

--- a/charts/steadybit-extension-container/templates/scc-rolebinding.yaml
+++ b/charts/steadybit-extension-container/templates/scc-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if or .Values.securityContextConstraint.create (and (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") (eq .Values.securityContextConstraint.create nil)) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "system:openshift:scc:{{ .Values.securityContextConstraint.name }}"
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "system:openshift:scc:{{ .Values.securityContextConstraint.name }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/steadybit-extension-container/templates/scc.yaml
+++ b/charts/steadybit-extension-container/templates/scc.yaml
@@ -1,0 +1,20 @@
+{{- if or .Values.securityContextConstraint.create (and (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") (eq .Values.securityContextConstraint.create nil)) -}}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ .Values.securityContextConstraint.name }}
+priority: null
+allowedCapabilities:
+  {{- .Values.containerSecurityContext.capabilities.add | toYaml | nindent 2 }}
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowHostDirVolumePlugin: true
+allowPrivilegeEscalation: true
+runAsUser:
+  type: MustRunAsNonRoot
+seccompProfiles:
+  - unconfined
+seLinuxContext:
+  type: MustRunAs
+{{- end -}}

--- a/charts/steadybit-extension-container/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/charts/steadybit-extension-container/tests/__snapshot__/daemonset_test.yaml.snap
@@ -72,6 +72,8 @@ manifest should match snapshot using containerd and using resource limits:
                   cpu: 200m
                   memory: 256Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -85,9 +87,6 @@ manifest should match snapshot using containerd and using resource limits:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -102,6 +101,10 @@ manifest should match snapshot using containerd and using resource limits:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -196,6 +199,8 @@ manifest should match snapshot using crio using podAnnotations and Labels:
                   cpu: 100m
                   memory: 48Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -209,9 +214,6 @@ manifest should match snapshot using crio using podAnnotations and Labels:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -226,6 +228,10 @@ manifest should match snapshot using crio using podAnnotations and Labels:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -318,6 +324,8 @@ manifest should match snapshot using docker:
                   cpu: 100m
                   memory: 48Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -331,9 +339,6 @@ manifest should match snapshot using docker:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -348,6 +353,10 @@ manifest should match snapshot using docker:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -444,6 +453,8 @@ manifest should match snapshot with TLS:
                   cpu: 100m
                   memory: 48Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -457,9 +468,6 @@ manifest should match snapshot with TLS:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -477,6 +485,10 @@ manifest should match snapshot with TLS:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -587,9 +599,6 @@ manifest should match snapshot with appArmorProfile for k8s >= 1.30:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -604,6 +613,10 @@ manifest should match snapshot with appArmorProfile for k8s >= 1.30:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -696,6 +709,8 @@ manifest should match snapshot with different containerPorts:
                   cpu: 100m
                   memory: 48Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -709,9 +724,6 @@ manifest should match snapshot with different containerPorts:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -726,6 +738,10 @@ manifest should match snapshot with different containerPorts:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -820,6 +836,8 @@ manifest should match snapshot with discover all deployments:
                   cpu: 100m
                   memory: 48Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -833,9 +851,6 @@ manifest should match snapshot with discover all deployments:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -850,6 +865,10 @@ manifest should match snapshot with discover all deployments:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -949,6 +968,8 @@ manifest should match snapshot with extra env vars:
                   cpu: 100m
                   memory: 48Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -962,9 +983,6 @@ manifest should match snapshot with extra env vars:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -979,6 +997,10 @@ manifest should match snapshot with extra env vars:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -1073,6 +1095,8 @@ manifest should match snapshot with extra labels:
                   cpu: 100m
                   memory: 48Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -1086,9 +1110,6 @@ manifest should match snapshot with extra labels:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -1103,6 +1124,10 @@ manifest should match snapshot with extra labels:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -1201,6 +1226,8 @@ manifest should match snapshot with mutual TLS:
                   cpu: 100m
                   memory: 48Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -1214,9 +1241,6 @@ manifest should match snapshot with mutual TLS:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -1237,6 +1261,10 @@ manifest should match snapshot with mutual TLS:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -1343,6 +1371,8 @@ manifest should match snapshot with mutual TLS using containerPaths:
                   cpu: 100m
                   memory: 48Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -1356,9 +1386,6 @@ manifest should match snapshot with mutual TLS using containerPaths:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -1373,6 +1400,10 @@ manifest should match snapshot with mutual TLS using containerPaths:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -1465,6 +1496,8 @@ manifest should match snapshot with podSecurityContext:
                   cpu: 100m
                   memory: 48Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -1478,9 +1511,6 @@ manifest should match snapshot with podSecurityContext:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -1496,7 +1526,10 @@ manifest should match snapshot with podSecurityContext:
           hostNetwork: true
           hostPID: true
           securityContext:
+            runAsNonRoot: true
             runAsUser: 2222
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -1589,6 +1622,8 @@ manifest should match snapshot with priority class:
                   cpu: 100m
                   memory: 48Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -1602,9 +1637,6 @@ manifest should match snapshot with priority class:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -1620,6 +1652,10 @@ manifest should match snapshot with priority class:
           hostNetwork: true
           hostPID: true
           priorityClassName: my-priority-class
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}
@@ -1712,6 +1748,8 @@ manifest should match snapshot with update strategy:
                   cpu: 100m
                   memory: 48Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -1725,9 +1763,6 @@ manifest should match snapshot with update strategy:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -1742,6 +1777,10 @@ manifest should match snapshot with update strategy:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-container
           volumes:
             - emptyDir: {}

--- a/charts/steadybit-extension-container/tests/__snapshot__/scc_test.yaml.snap
+++ b/charts/steadybit-extension-container/tests/__snapshot__/scc_test.yaml.snap
@@ -1,0 +1,114 @@
+forced rendering on kubernetes:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: system:openshift:scc:my-scc
+    rules:
+      - apiGroups:
+          - security.openshift.io
+        resourceNames:
+          - my-scc
+        resources:
+          - securitycontextconstraints
+        verbs:
+          - use
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: system:openshift:scc:my-scc
+      namespace: NAMESPACE
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:openshift:scc:my-scc
+    subjects:
+      - kind: ServiceAccount
+        name: steadybit-extension-container
+        namespace: NAMESPACE
+  3: |
+    allowHostDirVolumePlugin: true
+    allowHostNetwork: true
+    allowHostPID: true
+    allowHostPorts: true
+    allowPrivilegeEscalation: true
+    allowedCapabilities:
+      - SYS_ADMIN
+      - SYS_CHROOT
+      - SYS_RESOURCE
+      - SYS_PTRACE
+      - KILL
+      - NET_ADMIN
+      - DAC_OVERRIDE
+      - SETUID
+      - SETGID
+      - AUDIT_WRITE
+    apiVersion: security.openshift.io/v1
+    kind: SecurityContextConstraints
+    metadata:
+      name: my-scc
+    priority: null
+    runAsUser:
+      type: MustRunAsNonRoot
+    seLinuxContext:
+      type: MustRunAs
+    seccompProfiles:
+      - unconfined
+rendering by default on openshift:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: system:openshift:scc:steadybit-extension-container
+    rules:
+      - apiGroups:
+          - security.openshift.io
+        resourceNames:
+          - steadybit-extension-container
+        resources:
+          - securitycontextconstraints
+        verbs:
+          - use
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: system:openshift:scc:steadybit-extension-container
+      namespace: NAMESPACE
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:openshift:scc:steadybit-extension-container
+    subjects:
+      - kind: ServiceAccount
+        name: steadybit-extension-container
+        namespace: NAMESPACE
+  3: |
+    allowHostDirVolumePlugin: true
+    allowHostNetwork: true
+    allowHostPID: true
+    allowHostPorts: true
+    allowPrivilegeEscalation: true
+    allowedCapabilities:
+      - SYS_ADMIN
+      - SYS_CHROOT
+      - SYS_RESOURCE
+      - SYS_PTRACE
+      - KILL
+      - NET_ADMIN
+      - DAC_OVERRIDE
+      - SETUID
+      - SETGID
+      - AUDIT_WRITE
+    apiVersion: security.openshift.io/v1
+    kind: SecurityContextConstraints
+    metadata:
+      name: steadybit-extension-container
+    priority: null
+    runAsUser:
+      type: MustRunAsNonRoot
+    seLinuxContext:
+      type: MustRunAs
+    seccompProfiles:
+      - unconfined

--- a/charts/steadybit-extension-container/tests/scc_test.yaml
+++ b/charts/steadybit-extension-container/tests/scc_test.yaml
@@ -1,0 +1,37 @@
+templates:
+  - scc.yaml
+  - scc-clusterrole.yaml
+  - scc-rolebinding.yaml
+chart:
+  appVersion: v0.0.0
+capabilities:
+  majorVersion: 1
+  minorVersion: 30
+tests:
+  - it: not rendering on kubernetes
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: forced rendering on kubernetes
+    set:
+      securityContextConstraint:
+        create: true
+        name: "my-scc"
+    asserts:
+      - matchSnapshot: {}
+  - it: rendering by default on openshift
+    capabilities:
+      apiVersions:
+        - "security.openshift.io/v1/SecurityContextConstraints"
+    asserts:
+      - matchSnapshot: {}
+  - it: suppressed on openshift
+    capabilities:
+      apiVersions:
+        - "security.openshift.io/v1/SecurityContextConstraints"
+    set:
+      securityContextConstraint:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/steadybit-extension-container/values.yaml
+++ b/charts/steadybit-extension-container/values.yaml
@@ -80,6 +80,11 @@ serviceAccount:
   # serviceAccount.name -- The name of the ServiceAccount to use.
   name: steadybit-extension-container
 
+securityContextConstraint:
+  # securityContextConstraint.create -- Specifies whether a SecurityContextConstraint should be created. Defaults to true if the cluster is OpenShift.
+  create: null
+  name: steadybit-extension-container
+
 updateStrategy:
   # updateStrategy.type -- Specifies the strategy used to replace old Pods by new ones.
   type: RollingUpdate
@@ -113,7 +118,30 @@ affinity: {}
 priorityClassName: null
 
 # podSecurityContext -- SecurityContext to apply to the pod.
-podSecurityContext: {}
+podSecurityContext:
+  seccompProfile:
+    type: Unconfined
+  runAsNonRoot: true
+
+# containerSecurityContext -- SecurityContext to apply to the container.
+containerSecurityContext:
+  appArmorProfile:
+    type: Unconfined
+  seccompProfile:
+    type: Unconfined
+  readOnlyRootFilesystem: true
+  capabilities:
+    add:
+      - SYS_ADMIN
+      - SYS_CHROOT
+      - SYS_RESOURCE
+      - SYS_PTRACE
+      - KILL
+      - NET_ADMIN
+      - DAC_OVERRIDE
+      - SETUID
+      - SETGID
+      - AUDIT_WRITE
 
 # extraEnv -- Array with extra environment variables to add to the container
 # e.g:
@@ -141,20 +169,6 @@ containerRuntimes:
   cri-o:
     socket: /var/run/crio/crio.sock
     runcRoot: /run/runc
-
-securityContext:
-  capabilities:
-    add:
-      - SYS_ADMIN
-      - SYS_CHROOT
-      - SYS_RESOURCE
-      - SYS_PTRACE
-      - KILL
-      - NET_ADMIN
-      - DAC_OVERRIDE
-      - SETUID
-      - SETGID
-      - AUDIT_WRITE
 
 discovery:
   # discovery.disableExcludes -- Ignore discovery excludes specified by `steadybit.com/discovery-disabled` (mainly for internal use)


### PR DESCRIPTION
In order to improve installation on openshift, we need to avoid the hard-coded uid/gid in the helm chart