### PR TITLE
fix: use allowed cpus from target container

### DIFF
--- a/extcontainer/action_stress.go
+++ b/extcontainer/action_stress.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 Steadybit GmbH
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
 
 package extcontainer
 
@@ -92,7 +92,7 @@ func (a *stressAction) Prepare(ctx context.Context, state *StressActionState, re
 		return nil, err
 	}
 
-	readAndAdaptToContainerLimits(ctx, processInfo.CGroupPath, &opts)
+	readAndAdaptToContainerLimits(ctx, processInfo, &opts)
 
 	state.StressOpts = opts
 	state.ExecutionId = request.ExecutionId

--- a/extcontainer/action_stress_limit_helpers_test.go
+++ b/extcontainer/action_stress_limit_helpers_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
+
 package extcontainer
 
 import (
@@ -10,7 +13,6 @@ import (
 func Test_adaptToCpuContainerLimits(t *testing.T) {
 	type args struct {
 		cpuLimitInMilliCpu int
-		cpuCount           int
 		givenCpuWorkers    int
 		givenCpuLoad       int
 	}
@@ -27,7 +29,6 @@ func Test_adaptToCpuContainerLimits(t *testing.T) {
 			name: "worker-count not specified, desired cpu load can be handled by one worker",
 			args: args{
 				cpuLimitInMilliCpu: 200,
-				cpuCount:           4,
 				givenCpuLoad:       100,
 				givenCpuWorkers:    0,
 			},
@@ -40,7 +41,6 @@ func Test_adaptToCpuContainerLimits(t *testing.T) {
 			name: "worker-count not specified, desired cpu load needs multiple workers",
 			args: args{
 				cpuLimitInMilliCpu: 1500,
-				cpuCount:           4,
 				givenCpuLoad:       100,
 				givenCpuWorkers:    0,
 			},
@@ -53,7 +53,6 @@ func Test_adaptToCpuContainerLimits(t *testing.T) {
 			name: "worker-count not specified, desired 60% cpu fits to single worker",
 			args: args{
 				cpuLimitInMilliCpu: 1500,
-				cpuCount:           4,
 				givenCpuLoad:       60,
 				givenCpuWorkers:    0,
 			},
@@ -66,7 +65,6 @@ func Test_adaptToCpuContainerLimits(t *testing.T) {
 			name: "worker-count specified, desired 60% cpu is spread across workers",
 			args: args{
 				cpuLimitInMilliCpu: 1500,
-				cpuCount:           4,
 				givenCpuLoad:       60,
 				givenCpuWorkers:    3,
 			},
@@ -82,7 +80,7 @@ func Test_adaptToCpuContainerLimits(t *testing.T) {
 				CpuWorkers: &tt.args.givenCpuWorkers,
 				CpuLoad:    tt.args.givenCpuLoad,
 			}
-			adaptToCpuContainerLimits(tt.args.cpuLimitInMilliCpu, tt.args.cpuCount, &opts)
+			adaptToCpuContainerLimits(tt.args.cpuLimitInMilliCpu, &opts)
 			assert.Equal(t, tt.expected.adaptedCpuWorkers, *opts.CpuWorkers)
 			assert.Equal(t, tt.expected.adaptedCpuLoad, opts.CpuLoad)
 		})

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/rs/zerolog v1.33.0
 	github.com/steadybit/action-kit/go/action_kit_api/v2 v2.9.6
-	github.com/steadybit/action-kit/go/action_kit_commons v1.2.17
+	github.com/steadybit/action-kit/go/action_kit_commons v1.2.18
 	github.com/steadybit/action-kit/go/action_kit_sdk v1.1.14
 	github.com/steadybit/action-kit/go/action_kit_test v1.3.2
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.9.6 h1:Qci7Numf66mjCIRo7KDwHUimIxUZzq+GBfyv/1f/QCU=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.9.6/go.mod h1:ycF2RLgRsB8I/jD52aE+dKZKVru1GIEtmkcRcIR3vXk=
-github.com/steadybit/action-kit/go/action_kit_commons v1.2.17 h1:NOKvnUA/iZo7mlcgSK+c8EHjxAEYCLSdyk8KVQSXmv8=
-github.com/steadybit/action-kit/go/action_kit_commons v1.2.17/go.mod h1:GFLcaf/WluBIqnq+iSCEGkEqxnfB9h1I16IBR1T7kNQ=
+github.com/steadybit/action-kit/go/action_kit_commons v1.2.18 h1:zg3c7b/Dl0M/odtNMbbhwVn/EbnvPZO14IPwbFy9WbY=
+github.com/steadybit/action-kit/go/action_kit_commons v1.2.18/go.mod h1:GFLcaf/WluBIqnq+iSCEGkEqxnfB9h1I16IBR1T7kNQ=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.1.14 h1:x94RX+vh9Iyc0tS6BhiSpvknj+xE36AV0Nc3D5Yuub0=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.1.14/go.mod h1:Tp/klK5b7k+BCvb3JTSDZSNcnpFBaHauhndzOarnMW4=
 github.com/steadybit/action-kit/go/action_kit_test v1.3.2 h1:DFDznoWEbTGv+fiGYiRaq7tq5es9VTScjrWusRAbS08=


### PR DESCRIPTION
if a process is limited to a certain cpuset or
some of the configured processors are not online, we need to pass the number of workers to stress-ng as otherwise stress-ng will always use the configured number of processors.