### PR TITLE
docs: align CONTRIBUTING with canonical template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,16 @@
 # Contributing
 
+## Prerequisites
+
+To build and run this extension locally, you need:
+
+- [Go](https://go.dev/dl/) 1.26 or later
+- [GNU Make](https://www.gnu.org/software/make/)
+- [GoReleaser](https://goreleaser.com/) (used by `make build`)
+- [Docker](https://www.docker.com/) (required for `make container` and container-based tests)
+- [Helm](https://helm.sh/docs/intro/install/) and [helm-unittest](https://github.com/helm-unittest/helm-unittest) (for chart development; `make charttesting` and `make chartlint`)
+- [minikube](https://minikube.sigs.k8s.io/docs/start/) (used by `make prepare_audit` and the e2e tests)
+
 ## Getting Started
 
 1. Clone the repository
@@ -9,14 +20,17 @@
 
 ## Tasks
 
-The `Makefile` in the project root contains commands to easily run common admin tasks:
+The `Makefile` in the project root contains commands to easily run common admin tasks. Run `make help` to list all available targets.
 
-| Command        | Meaning                                                                                               |
-|----------------|-------------------------------------------------------------------------------------------------------|
-| `$ make tidy`  | Format all code using `go fmt` and tidy the `go.mod` file.                                            |
-| `$ make audit` | Run `go vet`, `staticheck`, execute all tests and verify required modules.                            |
-| `$ make build` | Build a binary for the extension. Creates a file called `extension` in the repository root directory. |
-| `$ make run`   | Build and then run the created binary.                                                                |
+| Command                | Meaning                                                                                               |
+|------------------------|-------------------------------------------------------------------------------------------------------|
+| `$ make tidy`          | Format all code using `go fmt` and tidy the `go.mod` file.                                            |
+| `$ make audit`         | Run `go vet`, `staticcheck`, execute all tests and verify required modules.                           |
+| `$ make build`         | Build a binary for the extension. Creates a file called `extension` in the repository root directory. |
+| `$ make run`           | Build and then run the created binary.                                                                |
+| `$ make container`     | Build the container image (`extension-container:latest`) using Docker buildx.                         |
+| `$ make prepare_audit` | Prepare a local minikube cluster (cpu/memory defaults) so the audit/e2e suites can run.               |
+| `$ make e2e-test`      | Run the end-to-end test suite under `./e2e/...` against a local minikube cluster.                     |
 
 ## Releasing the Code/Docker Image
 
@@ -36,15 +50,8 @@ Changing the Helm chart without bumping the version will result in the following
 
 ```
 > Releasing charts...
-    Error: error creating GitHub release steadybit-extension-scaffold-1.0.0: POST https://api.github.com/repos/steadybit/extension-scaffold/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
+    Error: error creating GitHub release steadybit-extension-container-1.0.0: POST https://api.github.com/repos/steadybit/extension-container/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
 ```
-
-## Building the Docker Image
-
-### Cross
-You need  an installation of cross (https://github.com/cross-rs/cross) to build the docker image for all platforms
-
-Therefore you also need rust (https://rustup.rs/)
 
 ## Contributor License Agreement (CLA)
 


### PR DESCRIPTION
Aligns this repo's CONTRIBUTING.md with the canonical structure used across the Steadybit Go extensions:

- Adds an explicit Prerequisites section listing the build tools (Go, GNU Make, GoReleaser, Docker, Helm + helm-unittest, minikube) with required versions.
- Documents the Makefile targets that actually exist (`tidy`, `audit`, `build`, `run`, `container`, `prepare_audit`, `e2e-test`) and points readers at `make help`.
- Drops the outdated "Building the Docker Image / Cross / Rust" note that no longer applies to the Go-based build.
- Keeps the release/Helm-chart/CLA sections in line with the other extension repos.

Local-build documentation is centralised here so README files can focus on deployment, install and configuration.