### PR TITLE
chore(deps): bump action_kit_commons to v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - If the target interface carries a user- or CNI-installed root qdisc (e.g. `htb`, `cake`) that cannot be restored afterwards, the attack now fails fast in the prepare step with a clear error instead of silently replacing it.
 - Optional fallback: set `STEADYBIT_EXTENSION_NETWORK_STRICT_ROOT_QDISC=true` (e.g. via `extraEnv`) to make network attacks refuse any interface whose root qdisc is not `noqueue` — including the kernel default `mq` — instead of replacing it. Off by default.
 - New `privileged` chart value (default `false`): runs the extension in privileged mode and switches the managed `SecurityContextConstraint` to allow it. Needed on hardened nodes (e.g. CIS/STIG) where the container root filesystem is mounted `nosuid`, which voids the binary's file capabilities and breaks fault injection (`nsenter: operation not permitted`).
+- Stress CPU with "All cores" on uncapped containers now uses every online CPU on hosts with more than 32 cores (previously capped at 32 due to a `Cpus_allowed` mask parsing bug).
 
 ## v1.6.7
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0
 	github.com/rs/zerolog v1.35.1
 	github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5
-	github.com/steadybit/action-kit/go/action_kit_commons v1.8.0
+	github.com/steadybit/action-kit/go/action_kit_commons v1.8.1
 	github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1
 	github.com/steadybit/action-kit/go/action_kit_test v1.4.7
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5 h1:WQkcNX2us3JyOrdnI3ttxX96nF2JAEQSx/zM8IQGwDo=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5/go.mod h1:g8gkKZCnaZaxtQseZ/L6/flv3Hutwy0xcVO7P1cbUMQ=
-github.com/steadybit/action-kit/go/action_kit_commons v1.8.0 h1:SbUchQAvPe20oVHa5EPjJgTkIULEVp/HVW7z3rn9BvA=
-github.com/steadybit/action-kit/go/action_kit_commons v1.8.0/go.mod h1:XQYeqLfvZKerb3BW7urnKptcaAAs6UHnn4f1vJatRgU=
+github.com/steadybit/action-kit/go/action_kit_commons v1.8.1 h1:hIIe1aMLvs+CSZYNS2QS6sV5/WbdvsfJ8jGhj+UFivU=
+github.com/steadybit/action-kit/go/action_kit_commons v1.8.1/go.mod h1:XQYeqLfvZKerb3BW7urnKptcaAAs6UHnn4f1vJatRgU=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1 h1:c83hiU+RLWjqouWR9baiidmYcTtDTdRa5rkWKFvdbc8=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1/go.mod h1:DMMqDn4QNetxAoEXSpS7xF/vV+aD6YIDl/CgWOi5ii8=
 github.com/steadybit/action-kit/go/action_kit_test v1.4.7 h1:DyW3xYKQTOpCy4GLOShUXYpzfTXH/JgWOcUi5WeC55k=


### PR DESCRIPTION
Bumps `action_kit_commons` to **v1.8.1**, which fixes `ReadCpusAllowedCount` for hosts with more than 32 CPUs (the `Cpus_allowed` mask is comma-separated 32-bit words; only the first was parsed). With this, **Stress CPU** with "All cores" (`workers=0`) on uncapped containers now spawns one worker per online CPU instead of being capped at 32.

See steadybit/action-kit#449.