### PR TITLE
feat: lower oom_score_adj on startup via extension-kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: lower `oom_score_adj` on startup via extension-kit's `extruntime.AdjustOOMScoreAdj()` to avoid being killed by the node OOM killer. The extension sets it directly using the `cap_sys_resource` file capability (default `-998`, configurable via `STEADYBIT_EXTENSION_OOM_SCORE_ADJ`).
+
 ## v1.6.8
 
 - Network attacks (delay, loss, corruption, bandwidth) on `hostNetwork: true` pods or on containers whose `eth0` already has a kernel-default root qdisc no longer fail with `NLM_F_REPLACE needed to override`. The root qdisc is now installed via `tc qdisc replace`; on revert the kernel restores its default (`mq`, `noqueue`, `fq_codel`, `pfifo_fast`, `fq`).

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY . .
 
 #Ambient set of capabilities are not really working, therefore we set the capabilities on the binary directly. More on this: https://github.com/kubernetes/kubernetes/issues/56374
 RUN --mount=type=cache,target="/root/.cache/go-build" GOCACHE=/root/.cache/go-build GOOS=$TARGETOS GOARCH=$TARGETARCH goreleaser build --snapshot="${BUILD_SNAPSHOT}" --single-target -o extension \
-    && setcap "cap_setuid,cap_sys_chroot,cap_setgid,cap_net_admin,cap_sys_admin,cap_dac_override,cap_sys_ptrace+eip" ./extension
+    && setcap "cap_setuid,cap_sys_chroot,cap_setgid,cap_net_admin,cap_sys_admin,cap_dac_override,cap_sys_ptrace,cap_sys_resource+eip" ./extension
 
 # As of today the runc binary from debian is built using golang 1.19.8 and will be flagged by CVE scanners as vulnerable to several CVEs.
 # We are dowonloading the runc binary from the official github release page and will use it instead of the one from the debian package.

--- a/charts/steadybit-extension-container/Chart.yaml
+++ b/charts/steadybit-extension-container/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-container
 description: Steadybit container extension Helm chart for Kubernetes.
-version: 1.5.14
+version: 1.5.15
 appVersion: v1.6.8
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-container/values.yaml
+++ b/charts/steadybit-extension-container/values.yaml
@@ -155,7 +155,9 @@ containerSecurityContext:
       # SETPCAP, MKNOD is needed to support the crun OCI runtime. Better performance / needed on openshift clusters >= 4.18
       - SETPCAP
       - MKNOD
-      # SYS_RESOURCE is optional. If you remove it is more likely that the stress cpu/io/memory, fill memory attack will more likely be oomkilled
+      # SYS_RESOURCE is required: it is set as a file capability (cap_sys_resource) on the binary so the
+      # extension can lower its own oom_score_adj and stress cpu/io/memory and fill-memory attacks are not
+      # oom-killed. Removing it here will prevent the extension from starting (execve fails with EPERM).
       - SYS_RESOURCE
 # extraEnv -- Array with extra environment variables to add to the container
 # e.g:

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -80,10 +80,6 @@ func TestWithMinikube(t *testing.T) {
 			Test: testStressCpu,
 		},
 		{
-			Name: "stress cpu without cap_sys_resource",
-			Test: testStressCpuNoCapSysResource,
-		},
-		{
 			Name: "stress memory",
 			Test: testStressMemory,
 		},
@@ -1271,15 +1267,6 @@ func testNetworkDNSErrorInjectionHostNetwork(t *testing.T, m *e2e.Minikube, e *e
 		})
 	}
 	requireAllSidecarsCleanedUp(t, m, e)
-}
-
-func testStressCpuNoCapSysResource(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
-	require.NoError(t, e.Reconfigure(map[string]string{"containerSecurityContext.capabilities.add": "{MKNOD,SETPCAP,KILL,NET_BIND_SERVICE,SYS_ADMIN,SYS_CHROOT,SYS_PTRACE,NET_ADMIN,BPF,DAC_OVERRIDE,SETUID,SETGID,AUDIT_WRITE}"}))
-	defer func() {
-		require.NoError(t, e.ResetConfig())
-	}()
-
-	testStressCpu(t, m, e)
 }
 
 func testStressCpu(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/steadybit/discovery-kit/go/discovery_kit_commons v0.3.1
 	github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5
 	github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1
-	github.com/steadybit/extension-kit v1.10.4
+	github.com/steadybit/extension-kit v1.10.5
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.21.0
 	google.golang.org/grpc v1.81.1

--- a/go.sum
+++ b/go.sum
@@ -283,8 +283,8 @@ github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5 h1:1yT/4Aw+lQvYXS
 github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5/go.mod h1:gOPfHZ3hw/7TMxEYCCTYnOz9tZ2ybNYa+MKmUbPXKIQ=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1 h1:CabRtfE70gt/4H/TgL/TRm54OkxWKbmPhTX2qEhzKZ4=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1/go.mod h1:PPJh5gSdVRKG/0qJCGJK5XnGxXat/v6UT8/2ilIbbX8=
-github.com/steadybit/extension-kit v1.10.4 h1:/XJH43+WepBz0xX7vPTB0X+nJeAB0Hu1fmB/mkecM+4=
-github.com/steadybit/extension-kit v1.10.4/go.mod h1:nHO0lQixaBUC2ynInJ3g2fQXoEqcoP6Qn3Iq2mcpQ4E=
+github.com/steadybit/extension-kit v1.10.5 h1:KSZP2vUA97QnFDhI3UAAmNg1iOv4n0ckXI/jjKrB3xc=
+github.com/steadybit/extension-kit v1.10.5/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 
 	extbuild.PrintBuildInformation()
 	extruntime.LogRuntimeInformation(zerolog.InfoLevel)
+	extruntime.AdjustOOMScoreAdj()
 
 	config.ParseConfiguration()
 	config.ValidateConfiguration()


### PR DESCRIPTION
## What

The extension now lowers its own `oom_score_adj` on startup via extension-kit's `extruntime.AdjustOOMScoreAdj()` (v1.10.5).

- `main.go` calls `extruntime.AdjustOOMScoreAdj()`.
- The binary is granted `cap_sys_resource` as a file capability (`setcap …+eip`), so the non-root extension process writes `/proc/self/oom_score_adj` **directly** — no root subprocess.
- Default target score `-998` (configurable via `STEADYBIT_EXTENSION_OOM_SCORE_ADJ`).
- Bumps `extension-kit` to `v1.10.5`.

## Why

Writing `oom_score_adj` requires `CAP_SYS_RESOURCE` effective. Adding it via the chart's `securityContext` alone is insufficient for a non-root container (it lands in the bounding set only); the file capability makes it effective on exec. The helper logs info on success and warn on failure (graceful degradation).

## Validation

Built and deployed this change to a local minikube: the extension process reached `oom_score_adj = -998` (was `997`) with no root subprocess, and `CapEff` included `cap_sys_resource`.

## Notes

- `SYS_RESOURCE` is already in the chart's `capabilities.add`; the values comment is updated to note it is now **required** (baked into the binary's file caps with the effective bit), so removing it would prevent the extension from starting.