### PR TITLE
feat: consolidate STEADYBIT_EXTENSION_NETWORK_{STRICT_ROOT_QDISC,SNAPSHOT_RESTORE} into one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- One env var instead of two for network-attack root-qdisc handling. `STEADYBIT_EXTENSION_NETWORK_SNAPSHOT_RESTORE` is gone; the snapshot/restore path now auto-activates whenever `STEADYBIT_EXTENSION_NETWORK_STRICT_ROOT_QDISC=false`. Operators wanting the customer-friendly behaviour on managed-cloud nodes (run the attack and preserve the tuned root) set strict to false and get snapshot for free.
+
 ## v1.6.10
 
 - feat: lower `oom_score_adj` on startup via extension-kit's `extruntime.AdjustOOMScoreAdj()` to avoid being killed by the node OOM killer. The extension sets it directly using the `cap_sys_resource` file capability (default `-998`, configurable via `STEADYBIT_EXTENSION_OOM_SCORE_ADJ`).

--- a/config/config.go
+++ b/config/config.go
@@ -25,20 +25,16 @@ type Specification struct {
 	Hostname                    string           `json:"hostname" split_words:"true" required:"false"`
 	DisallowHostNetwork         bool             `json:"disallowHostNetwork" split_words:"true" required:"false" default:"false"`
 	DisallowK8sNamespaces       []DisallowedName `json:"disallowK8sNamespaces" split_words:"true" required:"false"`
-	// NetworkStrictRootQdisc, when true, makes network attacks refuse (in the
-	// prepare step) any target interface whose root qdisc is not `noqueue` —
-	// including the kernel default `mq` on managed-cloud nodes. Opt-in fallback
-	// for customers who don't want attacks to replace a pre-existing root qdisc.
+	// NetworkStrictRootQdisc controls how network attacks behave on
+	// interfaces whose root qdisc isn't `noqueue` (e.g. the kernel default
+	// `mq` on managed-cloud nodes):
+	//   - true (default): refuse the attack in the prepare step.
+	//   - false: install the attack, but snapshot the root qdisc tree
+	//     beforehand and replay it on revert so the cloud-tuned state
+	//     (e.g. GKE's `mq + fq` with `buckets=32768 horizon=2s`) is
+	//     preserved instead of being reset to kernel defaults.
 	// STEADYBIT_EXTENSION_NETWORK_STRICT_ROOT_QDISC
 	NetworkStrictRootQdisc bool `json:"networkStrictRootQdisc" split_words:"true" required:"false" default:"true"`
-	// NetworkSnapshotRestore, when true, makes network attacks snapshot the
-	// root qdisc tree of every target interface before installing the attack,
-	// and replay it after revert. This preserves cloud-tuned root qdiscs
-	// (e.g. GKE's `mq + fq` with buckets=32768 horizon=2s) that would
-	// otherwise revert to kernel defaults after `tc qdisc del root` and leave
-	// the host network degraded until reboot.
-	// STEADYBIT_EXTENSION_NETWORK_SNAPSHOT_RESTORE
-	NetworkSnapshotRestore bool `json:"networkSnapshotRestore" split_words:"true" required:"false" default:"false"`
 }
 
 var (

--- a/main.go
+++ b/main.go
@@ -44,15 +44,11 @@ func main() {
 
 	log.Debug().Any("config", config.Config).Msg("Configuration loaded.")
 
-	// Opt-in fallback: refuse network attacks on interfaces whose root qdisc is
-	// not `noqueue` (incl. the kernel default `mq`) instead of replacing it.
+	// Single knob for the operator: strict mode refuses attacks on
+	// non-noqueue roots; lifting it activates the snapshot/restore path so
+	// cloud-tuned roots survive the attack.
 	netfault.SetStrictRootQdisc(config.Config.NetworkStrictRootQdisc)
-
-	// Opt-in snapshot/restore: capture the root qdisc tree before installing
-	// the attack and replay it on revert. Preserves cloud-tuned root qdiscs
-	// (e.g. GKE's mq + tuned fq children) that would otherwise revert to
-	// kernel defaults after `tc qdisc del root`.
-	netfault.SetSnapshotRestore(config.Config.NetworkSnapshotRestore)
+	netfault.SetSnapshotRestore(!config.Config.NetworkStrictRootQdisc)
 
 	exthealth.SetReady(false)
 	exthealth.StartProbes(int(config.Config.HealthPort))


### PR DESCRIPTION
## Summary

Follow-up to #459. The v1.6.10 release introduced two env vars for network-attack root-qdisc handling:

- `STEADYBIT_EXTENSION_NETWORK_STRICT_ROOT_QDISC` (default `true`) — refuse attacks on non-noqueue roots
- `STEADYBIT_EXTENSION_NETWORK_SNAPSHOT_RESTORE` (default `false`) — snapshot/restore the qdisc tree

The combination operators actually want is binary, not a matrix:

- **Strict** (`true`): never touch a non-noqueue root. Safe default.
- **Customer-friendly** (`false`): run the attack and snapshot/restore preserves the tuned root.

The `strict=false + snapshot=false` combo is the clobber-no-restore behaviour we're explicitly retiring; there's no useful third state.

## Change

`config/config.go`: drop the `NetworkSnapshotRestore` field.

`main.go`: wire the snapshot flag as the inverse of strict, in one place:

```go
netfault.SetStrictRootQdisc(config.Config.NetworkStrictRootQdisc)
netfault.SetSnapshotRestore(!config.Config.NetworkStrictRootQdisc)
```

No `action-kit` change; the underlying `SetSnapshotRestore` API stays for external consumers.

## Compatibility

`STEADYBIT_EXTENSION_NETWORK_SNAPSHOT_RESTORE` is no longer parsed. Operators who had set it (e.g. via `extraEnv` in their Helm values) will have their setting silently ignored — the effective behaviour is now driven entirely by the strict flag.

## Test plan

- [x] `go build ./...` clean
- [ ] CI runs full test suite
- [ ] Operator with `STRICT_ROOT_QDISC=false` sees `captured qdisc snapshot` + `qdisc restore verified` log lines on apply/revert
- [ ] Operator with `STRICT_ROOT_QDISC=true` (default) sees preflight refusal on managed-cloud nodes

Same change going into extension-host via PR #218.