### PR TITLE
chore: drop netfault.SetSnapshotRestore call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0
 	github.com/rs/zerolog v1.35.1
 	github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5
-	github.com/steadybit/action-kit/go/action_kit_commons v1.8.2
+	github.com/steadybit/action-kit/go/action_kit_commons v1.8.3-0.20260625053931-7b71afd9f584
 	github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1
 	github.com/steadybit/action-kit/go/action_kit_test v1.4.7
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0
 	github.com/rs/zerolog v1.35.1
 	github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5
-	github.com/steadybit/action-kit/go/action_kit_commons v1.8.3-0.20260625053931-7b71afd9f584
+	github.com/steadybit/action-kit/go/action_kit_commons v1.9.0
 	github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1
 	github.com/steadybit/action-kit/go/action_kit_test v1.4.7
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5 h1:WQkcNX2us3JyOrdnI3ttxX96nF2JAEQSx/zM8IQGwDo=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5/go.mod h1:g8gkKZCnaZaxtQseZ/L6/flv3Hutwy0xcVO7P1cbUMQ=
-github.com/steadybit/action-kit/go/action_kit_commons v1.8.2 h1:9PtF3VpFGFO2qO6sgLfuvNv79rKGbUZKLd8LUYFXxMU=
-github.com/steadybit/action-kit/go/action_kit_commons v1.8.2/go.mod h1:Dg5Q26LfchJnGKrMubHnVXzxaJL3ykx0naNbH05lL+Q=
+github.com/steadybit/action-kit/go/action_kit_commons v1.8.3-0.20260625053931-7b71afd9f584 h1:7qbgdcXdHMXjDatNusITuFvPdDXMgCYQywykuGv9Hag=
+github.com/steadybit/action-kit/go/action_kit_commons v1.8.3-0.20260625053931-7b71afd9f584/go.mod h1:Dg5Q26LfchJnGKrMubHnVXzxaJL3ykx0naNbH05lL+Q=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1 h1:c83hiU+RLWjqouWR9baiidmYcTtDTdRa5rkWKFvdbc8=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1/go.mod h1:DMMqDn4QNetxAoEXSpS7xF/vV+aD6YIDl/CgWOi5ii8=
 github.com/steadybit/action-kit/go/action_kit_test v1.4.7 h1:DyW3xYKQTOpCy4GLOShUXYpzfTXH/JgWOcUi5WeC55k=

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5 h1:WQkcNX2us3JyOrdnI3ttxX96nF2JAEQSx/zM8IQGwDo=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5/go.mod h1:g8gkKZCnaZaxtQseZ/L6/flv3Hutwy0xcVO7P1cbUMQ=
-github.com/steadybit/action-kit/go/action_kit_commons v1.8.3-0.20260625053931-7b71afd9f584 h1:7qbgdcXdHMXjDatNusITuFvPdDXMgCYQywykuGv9Hag=
-github.com/steadybit/action-kit/go/action_kit_commons v1.8.3-0.20260625053931-7b71afd9f584/go.mod h1:Dg5Q26LfchJnGKrMubHnVXzxaJL3ykx0naNbH05lL+Q=
+github.com/steadybit/action-kit/go/action_kit_commons v1.9.0 h1:Vc7zdwr40VzcDTUKWqylqcNZVxZfidTU2/UikFXKvbQ=
+github.com/steadybit/action-kit/go/action_kit_commons v1.9.0/go.mod h1:Dg5Q26LfchJnGKrMubHnVXzxaJL3ykx0naNbH05lL+Q=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1 h1:c83hiU+RLWjqouWR9baiidmYcTtDTdRa5rkWKFvdbc8=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1/go.mod h1:DMMqDn4QNetxAoEXSpS7xF/vV+aD6YIDl/CgWOi5ii8=
 github.com/steadybit/action-kit/go/action_kit_test v1.4.7 h1:DyW3xYKQTOpCy4GLOShUXYpzfTXH/JgWOcUi5WeC55k=

--- a/main.go
+++ b/main.go
@@ -48,7 +48,6 @@ func main() {
 	// non-noqueue roots; lifting it activates the snapshot/restore path so
 	// cloud-tuned roots survive the attack.
 	netfault.SetStrictRootQdisc(config.Config.NetworkStrictRootQdisc)
-	netfault.SetSnapshotRestore(!config.Config.NetworkStrictRootQdisc)
 
 	exthealth.SetReady(false)
 	exthealth.StartProbes(int(config.Config.HealthPort))


### PR DESCRIPTION
## Summary

Follow-up to action-kit [#454](https://github.com/steadybit/action-kit/pull/454), which removes `SetSnapshotRestore` from action-kit-commons. The snapshot/restore path now runs implicitly whenever strict mode is OFF, so the extension-level `SetSnapshotRestore(!cfg.NetworkStrictRootQdisc)` call is no longer needed.

## Change

`main.go`: drop the one-line call. `go.mod` pinned to PR #454's HEAD pseudo-version for now.

## Blocked on

- action-kit #454 needs to merge and a new release of `action_kit_commons` to be tagged.
- After that, re-pin `go.mod` to the released tag and this PR is mergeable.

## Test plan

- [x] `go build ./...` clean
- [ ] CI runs the full suite (including e2e)