### PR TITLE
feat: thread qdisc snapshot through per-execution state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The pre-attack qdisc snapshot now lives in the action's per-execution state instead of an in-memory map in the extension process. An extension pod restart between Start and Stop no longer loses the snapshot, so Stop still restores the cloud-tuned root tree. Requires `action_kit_commons` v1.10.0.
 - One env var instead of two for network-attack root-qdisc handling. `STEADYBIT_EXTENSION_NETWORK_SNAPSHOT_RESTORE` is gone; the snapshot/restore path now auto-activates whenever `STEADYBIT_EXTENSION_NETWORK_STRICT_ROOT_QDISC=false`. Operators wanting the customer-friendly behaviour on managed-cloud nodes (run the attack and preserve the tuned root) set strict to false and get snapshot for free.
 
 ## v1.6.10

--- a/extcontainer/action_network.go
+++ b/extcontainer/action_network.go
@@ -44,6 +44,12 @@ type NetworkActionState struct {
 	Sidecar     netfault.SidecarOpts
 	ContainerID string
 	TargetLabel string
+	// QdiscSnapshot holds the pre-attack qdisc tree captured by netfault.Apply.
+	// It travels through the action_kit_sdk per-execution state so Stop can
+	// hand it back to netfault.Revert and restore the original (cloud-tuned)
+	// root after the attack tree is torn down. Empty when strict-mode is on,
+	// the attack doesn't touch a tc root, or the capture itself errored.
+	QdiscSnapshot netfault.QdiscSnapshot
 }
 
 // Make sure networkAction implements all required interfaces
@@ -197,7 +203,8 @@ func (a *networkAction) Start(ctx context.Context, state *NetworkActionState) (*
 		},
 	}}
 
-	err = netfault.Apply(ctx, netfault.NewRuncRunner(a.ociRuntime, state.Sidecar), opts)
+	snap, err := netfault.Apply(ctx, netfault.NewRuncRunner(a.ociRuntime, state.Sidecar), opts)
+	state.QdiscSnapshot = snap
 	if err != nil {
 		var toomany *netfault.ErrTooManyTcCommands
 		if errors.As(err, &toomany) {
@@ -237,7 +244,7 @@ func (a *networkAction) Stop(_ context.Context, state *NetworkActionState) (*act
 		}, nil
 	}
 
-	if err := netfault.Revert(ctx, netfault.NewRuncRunner(a.ociRuntime, state.Sidecar), opts); err != nil {
+	if err := netfault.Revert(ctx, netfault.NewRuncRunner(a.ociRuntime, state.Sidecar), opts, state.QdiscSnapshot); err != nil {
 		return nil, extension_kit.ToError("Failed to revert network settings.", err)
 	}
 	return nil, nil

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0
 	github.com/rs/zerolog v1.35.1
 	github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5
-	github.com/steadybit/action-kit/go/action_kit_commons v1.9.0
+	github.com/steadybit/action-kit/go/action_kit_commons v1.10.0
 	github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1
 	github.com/steadybit/action-kit/go/action_kit_test v1.4.7
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5 h1:WQkcNX2us3JyOrdnI3ttxX96nF2JAEQSx/zM8IQGwDo=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5/go.mod h1:g8gkKZCnaZaxtQseZ/L6/flv3Hutwy0xcVO7P1cbUMQ=
-github.com/steadybit/action-kit/go/action_kit_commons v1.9.0 h1:Vc7zdwr40VzcDTUKWqylqcNZVxZfidTU2/UikFXKvbQ=
-github.com/steadybit/action-kit/go/action_kit_commons v1.9.0/go.mod h1:Dg5Q26LfchJnGKrMubHnVXzxaJL3ykx0naNbH05lL+Q=
+github.com/steadybit/action-kit/go/action_kit_commons v1.10.0 h1:KwylN8dtI7chs0gB953jpj5k0zVTrXqmsxChsCzL1Po=
+github.com/steadybit/action-kit/go/action_kit_commons v1.10.0/go.mod h1:Dg5Q26LfchJnGKrMubHnVXzxaJL3ykx0naNbH05lL+Q=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1 h1:c83hiU+RLWjqouWR9baiidmYcTtDTdRa5rkWKFvdbc8=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1/go.mod h1:DMMqDn4QNetxAoEXSpS7xF/vV+aD6YIDl/CgWOi5ii8=
 github.com/steadybit/action-kit/go/action_kit_test v1.4.7 h1:DyW3xYKQTOpCy4GLOShUXYpzfTXH/JgWOcUi5WeC55k=


### PR DESCRIPTION
## Summary

- Bump `action_kit_commons` to `v1.10.0`, which moves the netfault snapshot out of a process-local map and into the value `netfault.Apply` returns.
- `NetworkActionState` gains a `QdiscSnapshot` field. `Start` stashes what `Apply` returns; `Stop` hands it back to `Revert`. The action_kit_sdk serializes state as JSON so the snapshot rides through a pod restart cleanly.

## Why

With the old in-memory store, restarting the extension pod between `Start` and `Stop` lost the snapshot and `Stop` degraded to the kernel-default-restore behaviour — exactly the regression v1.6.10 was added to fix. With the snapshot in per-execution state, the Steadybit platform holds it for the duration of the experiment and `Stop` restores the original tree regardless of the extension pod's lifecycle.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./extcontainer -short` passes
- [ ] CI green