### PR TITLE
fix: dedupe network attacks across containers sharing a pod's netns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: dedupe network attacks across containers that share a pod's network namespace. In Kubernetes every container in a pod shares the pod's netns, so an experiment targeting multiple containers in the same pod fired multiple `tc` applies against the same netns — the second apply then collided at the kernel level (e.g. `htb.change` rejected because the first apply had installed active classes at handle `1:`). The first Start on a netns now applies the attack ("primary"), later Starts on the same netns no-op ("shadow"), and Stop mirrors the same split.
+
 ## v1.6.10
 
 - feat: opt-in qdisc snapshot/restore for network attacks. Set `STEADYBIT_EXTENSION_NETWORK_STRICT_ROOT_QDISC=false` (e.g. via `extraEnv`) to make Apply capture the root qdisc tree (qdiscs + filters) of every target interface and Revert replay it after the attack's `tc del`. Preserves cloud-tuned root qdiscs (e.g. GKE's `mq + fq` with `buckets=32768 horizon=2s`) that would otherwise revert to kernel defaults after `tc qdisc del root` and leave the host network degraded until reboot. Off by default; Linux only.

--- a/extcontainer/action_network.go
+++ b/extcontainer/action_network.go
@@ -51,13 +51,23 @@ type NetworkActionState struct {
 	// the attack doesn't touch a tc root, or the capture itself errored.
 	QdiscSnapshot netfault.QdiscSnapshot
 	// IsShadow is true when this action's Start found another concurrent
-	// action already attacking the same netns (multi-container pods share a
-	// netns — see netns_dedup.go). Shadow actions do NOT install their own
-	// tc rules; only the first (primary) Start applies. Stop mirrors the
-	// same split: the primary reverts, shadows no-op. The flag lives on
-	// state so the primary/shadow decision survives an extension pod
-	// restart between Start and Stop.
+	// action already attacking the same netns WITH IDENTICAL OPTS
+	// (multi-container pods share a netns — see netns_dedup.go). Shadow
+	// actions do NOT install their own tc rules; only the first (primary)
+	// Start applies. Stop mirrors the same split: the primary reverts,
+	// shadows no-op. Different opts on a sibling take the passthrough
+	// branch instead of shadowing, so this stays false there. The flag
+	// lives on state so the primary/shadow decision survives an extension
+	// pod restart between Start and Stop.
 	IsShadow bool
+	// NetnsClaimed records whether Start incremented the netns tracker
+	// counter for this action. True for primary and shadow (both hold a
+	// claim). False for passthrough (netns was already claimed with
+	// different opts, so we didn't touch the tracker). Stop uses this to
+	// decide whether it owns a release — without it, an opts-decode or
+	// revert error inside Stop would leak the claim for the rest of the
+	// process's life and silently shadow every future Start on this netns.
+	NetnsClaimed bool
 }
 
 // Make sure networkAction implements all required interfaces
@@ -211,32 +221,51 @@ func (a *networkAction) Start(ctx context.Context, state *NetworkActionState) (*
 		},
 	}}
 
-	// If another concurrent action is already attacking this netns
-	// (multi-container pods share a netns — see netns_dedup.go), mark this
-	// Start as a shadow and skip Apply. The primary Start does the actual
-	// tc install; Stop mirrors the decision via state.IsShadow.
+	// Coordinate with sibling containers that share this netns (Kubernetes
+	// pods do this by default — see netns_dedup.go). Three outcomes:
+	//   Primary: first Start on this netns — apply the attack.
+	//   Shadow: sibling already applied with IDENTICAL opts — skip apply.
+	//   Passthrough: sibling already applied with DIFFERENT opts — proceed
+	//     to netfault, which will accept as compatible or reject with a
+	//     visible error (matches pre-PR behavior for combined attacks).
 	nsID := netNsID(state.Sidecar.TargetProcess)
-	if !claimNetnsForAttack(nsID) {
+	switch claimNetnsForAttack(nsID, state.NetworkOpts) {
+	case ClaimShadow:
 		state.IsShadow = true
+		state.NetnsClaimed = true
 		log.Info().
 			Str("containerId", state.ContainerID).
 			Str("netNs", nsID).
-			Msg("skipping network attack apply — another container on the same netns already attacked it (shadow)")
+			Msg("skipping network attack apply — sibling container on the same netns already applied this exact attack (shadow)")
 		result.Messages = new(append(*result.Messages, action_kit_api.Message{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Skipping apply for container %s — the target's network namespace is already being attacked by a sibling container in the same pod.", state.TargetLabel),
+			Message: fmt.Sprintf("Skipping apply for container %s — a sibling container in the same pod is already running this attack on the shared network namespace.", state.TargetLabel),
 		}))
 		return &result, nil
+	case ClaimPrimary:
+		state.NetnsClaimed = true
+	case ClaimPassthrough:
+		// netns has an active attack with DIFFERENT opts. Don't dedup —
+		// let netfault decide. state.NetnsClaimed stays false so Stop
+		// doesn't try to release a counter we never took.
+		log.Debug().
+			Str("containerId", state.ContainerID).
+			Str("netNs", nsID).
+			Msg("sibling container on the same netns is running a different attack; passing this Start through to netfault")
 	}
 
 	snap, err := netfault.Apply(ctx, netfault.NewRuncRunner(a.ociRuntime, state.Sidecar), opts)
 	state.QdiscSnapshot = snap
 	if err != nil {
-		// Apply failed — release the netns claim so subsequent Starts have
-		// a chance to try. Without this a failed primary would permanently
-		// block sibling containers from being attacked in the same
-		// extension-container process.
-		releaseNetnsForAttack(nsID)
+		// Apply failed — release the netns claim (if we took one) so
+		// subsequent Starts have a chance to try. Without this a failed
+		// primary would permanently block sibling containers from being
+		// attacked in the same extension-container process. Passthrough
+		// never claimed, so nothing to release there.
+		if state.NetnsClaimed {
+			releaseNetnsForAttack(nsID)
+			state.NetnsClaimed = false
+		}
 		var toomany *netfault.ErrTooManyTcCommands
 		if errors.As(err, &toomany) {
 			result.Messages = new(append(*result.Messages, action_kit_api.Message{
@@ -254,12 +283,22 @@ func (a *networkAction) Start(ctx context.Context, state *NetworkActionState) (*
 func (a *networkAction) Stop(_ context.Context, state *NetworkActionState) (*action_kit_api.StopResult, error) {
 	ctx := context.Background() // don't use the context as the action should be stopped even if the request context is cancelled
 
+	// Release the netns claim once at the end of Stop, regardless of which
+	// exit path we take. Guarded by NetnsClaimed so a passthrough Start
+	// (never claimed) doesn't accidentally release someone else's claim,
+	// and to keep the release exactly once even on the opts-decode /
+	// revert-error early returns below.
+	if state.NetnsClaimed {
+		defer func() {
+			releaseNetnsForAttack(netNsID(state.Sidecar.TargetProcess))
+		}()
+	}
+
 	// Shadow actions never applied — their Start deferred to a sibling
 	// container's primary. Their Stop must not revert, or the primary's
 	// attack would be torn down early. See netns_dedup.go for the full
 	// primary/shadow model.
 	if state.IsShadow {
-		releaseNetnsForAttack(netNsID(state.Sidecar.TargetProcess))
 		log.Info().
 			Str("containerId", state.ContainerID).
 			Msg("skipping network attack revert — this container was a shadow (sibling primary owns the attack)")
@@ -285,7 +324,6 @@ func (a *networkAction) Stop(_ context.Context, state *NetworkActionState) (*act
 			Str("containerId", state.ContainerID).
 			Msg("target network namespace does not exist anymore, no revert necessary")
 
-		releaseNetnsForAttack(netNsID(state.Sidecar.TargetProcess))
 		return &action_kit_api.StopResult{
 			Messages: &[]action_kit_api.Message{
 				{
@@ -299,7 +337,6 @@ func (a *networkAction) Stop(_ context.Context, state *NetworkActionState) (*act
 	if err := netfault.Revert(ctx, netfault.NewRuncRunner(a.ociRuntime, state.Sidecar), opts, state.QdiscSnapshot); err != nil {
 		return nil, extension_kit.ToError("Failed to revert network settings.", err)
 	}
-	releaseNetnsForAttack(netNsID(state.Sidecar.TargetProcess))
 	return nil, nil
 }
 

--- a/extcontainer/action_network.go
+++ b/extcontainer/action_network.go
@@ -50,6 +50,14 @@ type NetworkActionState struct {
 	// root after the attack tree is torn down. Empty when strict-mode is on,
 	// the attack doesn't touch a tc root, or the capture itself errored.
 	QdiscSnapshot netfault.QdiscSnapshot
+	// IsShadow is true when this action's Start found another concurrent
+	// action already attacking the same netns (multi-container pods share a
+	// netns — see netns_dedup.go). Shadow actions do NOT install their own
+	// tc rules; only the first (primary) Start applies. Stop mirrors the
+	// same split: the primary reverts, shadows no-op. The flag lives on
+	// state so the primary/shadow decision survives an extension pod
+	// restart between Start and Stop.
+	IsShadow bool
 }
 
 // Make sure networkAction implements all required interfaces
@@ -203,9 +211,32 @@ func (a *networkAction) Start(ctx context.Context, state *NetworkActionState) (*
 		},
 	}}
 
+	// If another concurrent action is already attacking this netns
+	// (multi-container pods share a netns — see netns_dedup.go), mark this
+	// Start as a shadow and skip Apply. The primary Start does the actual
+	// tc install; Stop mirrors the decision via state.IsShadow.
+	nsID := netNsID(state.Sidecar.TargetProcess)
+	if !claimNetnsForAttack(nsID) {
+		state.IsShadow = true
+		log.Info().
+			Str("containerId", state.ContainerID).
+			Str("netNs", nsID).
+			Msg("skipping network attack apply — another container on the same netns already attacked it (shadow)")
+		result.Messages = new(append(*result.Messages, action_kit_api.Message{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("Skipping apply for container %s — the target's network namespace is already being attacked by a sibling container in the same pod.", state.TargetLabel),
+		}))
+		return &result, nil
+	}
+
 	snap, err := netfault.Apply(ctx, netfault.NewRuncRunner(a.ociRuntime, state.Sidecar), opts)
 	state.QdiscSnapshot = snap
 	if err != nil {
+		// Apply failed — release the netns claim so subsequent Starts have
+		// a chance to try. Without this a failed primary would permanently
+		// block sibling containers from being attacked in the same
+		// extension-container process.
+		releaseNetnsForAttack(nsID)
 		var toomany *netfault.ErrTooManyTcCommands
 		if errors.As(err, &toomany) {
 			result.Messages = new(append(*result.Messages, action_kit_api.Message{
@@ -222,6 +253,26 @@ func (a *networkAction) Start(ctx context.Context, state *NetworkActionState) (*
 
 func (a *networkAction) Stop(_ context.Context, state *NetworkActionState) (*action_kit_api.StopResult, error) {
 	ctx := context.Background() // don't use the context as the action should be stopped even if the request context is cancelled
+
+	// Shadow actions never applied — their Start deferred to a sibling
+	// container's primary. Their Stop must not revert, or the primary's
+	// attack would be torn down early. See netns_dedup.go for the full
+	// primary/shadow model.
+	if state.IsShadow {
+		releaseNetnsForAttack(netNsID(state.Sidecar.TargetProcess))
+		log.Info().
+			Str("containerId", state.ContainerID).
+			Msg("skipping network attack revert — this container was a shadow (sibling primary owns the attack)")
+		return &action_kit_api.StopResult{
+			Messages: &[]action_kit_api.Message{
+				{
+					Level:   extutil.Ptr(action_kit_api.Info),
+					Message: fmt.Sprintf("Skipping revert for container %s — a sibling container in the same pod owns the attack on the shared network namespace.", state.TargetLabel),
+				},
+			},
+		}, nil
+	}
+
 	opts, err := a.optsDecoder(state.NetworkOpts)
 	if err != nil {
 		return nil, extension_kit.ToError("Failed to deserialize network settings.", err)
@@ -234,6 +285,7 @@ func (a *networkAction) Stop(_ context.Context, state *NetworkActionState) (*act
 			Str("containerId", state.ContainerID).
 			Msg("target network namespace does not exist anymore, no revert necessary")
 
+		releaseNetnsForAttack(netNsID(state.Sidecar.TargetProcess))
 		return &action_kit_api.StopResult{
 			Messages: &[]action_kit_api.Message{
 				{
@@ -247,6 +299,7 @@ func (a *networkAction) Stop(_ context.Context, state *NetworkActionState) (*act
 	if err := netfault.Revert(ctx, netfault.NewRuncRunner(a.ociRuntime, state.Sidecar), opts, state.QdiscSnapshot); err != nil {
 		return nil, extension_kit.ToError("Failed to revert network settings.", err)
 	}
+	releaseNetnsForAttack(netNsID(state.Sidecar.TargetProcess))
 	return nil, nil
 }
 

--- a/extcontainer/netns_dedup.go
+++ b/extcontainer/netns_dedup.go
@@ -3,6 +3,8 @@
 package extcontainer
 
 import (
+	"bytes"
+	"encoding/json"
 	"strconv"
 	"sync"
 
@@ -19,27 +21,69 @@ import (
 // then collides at the kernel level (e.g. htb.change rejects because the
 // first apply already installed active classes at handle 1:).
 //
-// The tracker gives us a per-netns claim: the first Start on a netns is
-// "primary" and applies the attack; subsequent Starts on the same netns are
-// "shadow" and no-op. Stop mirrors that decision — the primary reverts,
-// shadows no-op — using the IsShadow flag persisted on NetworkActionState.
+// The tracker gives us three outcomes per Start:
 //
-// The in-memory counter here only coordinates concurrent Start calls within
-// a single extension-container process. IsShadow lives on state, so Stop
-// still does the right thing after an extension pod restart.
+//   - **Primary**: first Start to arrive on this netns. Applies the attack.
+//   - **Shadow**: a later Start arrives on a netns whose primary has the
+//     IDENTICAL opts. Skips apply, no-ops on stop. Ref-counted so Stop
+//     properly cleans up the claim.
+//   - **Passthrough**: a later Start arrives on a netns whose primary has
+//     DIFFERENT opts (e.g. different attack type, or delay vs blackhole).
+//     Doesn't touch the tracker at all — the request flows through to
+//     netfault, whose `doesConflictWith`/`pushActiveNetfault` layer then
+//     decides whether to accept or reject with a visible error. This
+//     preserves the pre-PR user-visible-error behavior for combined
+//     attacks on the same pod, which the netns-only variant would have
+//     silently no-op'd.
+//
+// The primary/shadow decision lives on NetworkActionState (`IsShadow`,
+// `NetnsClaimed`), so Stop still routes correctly after an extension pod
+// restart between Start and Stop.
 //
 // Restart caveat: if the extension pod restarts *between* the primary's
 // Start (already applied) and a shadow's Start (hasn't run yet), the
-// tracker resets to empty; the shadow's Start then thinks it's the primary
-// and tries to apply, which will collide with the primary's still-installed
-// tc rules. This is a rare race — usually all Starts for one experiment
-// arrive within the same second — and the collision surfaces as a normal
-// Apply error the platform can retry. Persisting the tracker to disk to
-// close the race isn't worth the complexity today.
+// in-memory tracker resets to empty; the shadow's Start then thinks it's
+// the primary and tries to apply, which will collide with the primary's
+// still-installed tc rules. Rare in practice — Start calls usually arrive
+// within the same second — and the collision surfaces as a normal Apply
+// error the platform can retry. Persisting the tracker to disk to close
+// the race isn't worth the complexity today.
 var netnsAttackTracker = struct {
 	sync.Mutex
-	active map[string]int
-}{active: map[string]int{}}
+	active map[string]*netnsEntry
+}{active: map[string]*netnsEntry{}}
+
+type netnsEntry struct {
+	// count is the number of live primary+shadow claims. Passthroughs are
+	// not counted (they don't touch the tracker).
+	count int
+	// opts is the serialized attack opts of the primary. Later Starts on
+	// this netns compare their opts against this: identical -> shadow,
+	// different -> passthrough. json.RawMessage bytes come from the same
+	// json.Marshal in the same process across sibling containers, so byte
+	// equality is a reliable "same attack" check for the dedup case.
+	opts json.RawMessage
+}
+
+// ClaimResult is what claimNetnsForAttack tells Start to do.
+type ClaimResult int
+
+const (
+	// ClaimPrimary is the first (or freshest, after full release) claim on
+	// this netns. Start applies the attack. Stop must release the counter
+	// exactly once via NetnsClaimed=true on state.
+	ClaimPrimary ClaimResult = iota
+	// ClaimShadow means a sibling container already claimed this netns
+	// with IDENTICAL opts. Start skips apply. Stop skips revert. Release
+	// counter exactly once via NetnsClaimed=true.
+	ClaimShadow
+	// ClaimPassthrough means a sibling claimed this netns with DIFFERENT
+	// opts. Start proceeds normally (Apply is called). Netfault then decides
+	// whether to accept as compatible or reject as conflicting. Stop reverts
+	// normally. Passthrough does NOT touch the counter — NetnsClaimed=false
+	// on state so Stop won't try to release.
+	ClaimPassthrough
+)
 
 // netNsID returns the tracker key for a target process's network namespace.
 // Matches the format used by netfault's runcRunner.id() so both layers key
@@ -58,38 +102,53 @@ func netNsID(process ociruntime.LinuxProcessInfo) string {
 	return ""
 }
 
-// claimNetnsForAttack increments the netns counter and reports whether this
-// caller is the first (should apply the attack). Later callers on the same
-// netns receive false (should skip apply and mark themselves as shadow).
-// Empty id short-circuits to true so an unknown-netns target still applies
-// — safer than silently no-op'ing.
-func claimNetnsForAttack(id string) bool {
+// claimNetnsForAttack inspects the tracker for the given netns and returns
+// what the caller's Start should do. See the doc on ClaimResult for the
+// three outcomes. `opts` is the serialized attack opts (state.NetworkOpts)
+// — the same JSON bytes any sibling container would produce for the same
+// attack in the same process.
+//
+// Empty id short-circuits to ClaimPrimary so an unknown-netns target still
+// applies — safer than silently no-op'ing.
+func claimNetnsForAttack(id string, opts json.RawMessage) ClaimResult {
 	if id == "" {
-		return true
+		return ClaimPrimary
 	}
 	netnsAttackTracker.Lock()
 	defer netnsAttackTracker.Unlock()
-	first := netnsAttackTracker.active[id] == 0
-	netnsAttackTracker.active[id]++
-	return first
+	entry, exists := netnsAttackTracker.active[id]
+	if !exists {
+		netnsAttackTracker.active[id] = &netnsEntry{count: 1, opts: opts}
+		return ClaimPrimary
+	}
+	if bytes.Equal(entry.opts, opts) {
+		entry.count++
+		return ClaimShadow
+	}
+	// Different opts — let it through to netfault, don't touch the
+	// tracker. Netfault's own doesConflictWith / pushActiveNetfault will
+	// either allow both or reject the newcomer with a visible error.
+	return ClaimPassthrough
 }
 
-// releaseNetnsForAttack decrements the netns counter after a Stop. The
-// return value isn't used by the current call sites (Stop consults
-// NetworkActionState.IsShadow to decide whether to revert), but keeping it
-// symmetric with claim makes future refcount-based decisions straightforward.
-// Idempotent when the tracker doesn't know about this netns (e.g. after a
-// restart wiped the in-memory state).
+// releaseNetnsForAttack decrements the netns counter after a Stop. Only
+// call when the corresponding Start returned ClaimPrimary or ClaimShadow
+// (checked at the call site via state.NetnsClaimed). Idempotent when the
+// tracker doesn't know about this netns (e.g. after a restart wiped the
+// in-memory state).
 func releaseNetnsForAttack(id string) {
 	if id == "" {
 		return
 	}
 	netnsAttackTracker.Lock()
 	defer netnsAttackTracker.Unlock()
-	n := netnsAttackTracker.active[id]
-	if n <= 1 {
+	entry, exists := netnsAttackTracker.active[id]
+	if !exists {
+		return
+	}
+	if entry.count <= 1 {
 		delete(netnsAttackTracker.active, id)
 		return
 	}
-	netnsAttackTracker.active[id] = n - 1
+	entry.count--
 }

--- a/extcontainer/netns_dedup.go
+++ b/extcontainer/netns_dedup.go
@@ -1,0 +1,95 @@
+// Copyright 2026 steadybit GmbH. All rights reserved.
+
+package extcontainer
+
+import (
+	"strconv"
+	"sync"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/steadybit/action-kit/go/action_kit_commons/ociruntime"
+)
+
+// netnsAttackTracker coordinates network attacks between multiple containers
+// that share a network namespace. In Kubernetes this is the default for
+// every pod: all containers in the pod share the pod's netns so they see
+// each other on localhost. Steadybit fires an apply per container target;
+// the platform doesn't know they share a netns, so extension-container ends
+// up running the SAME tc-attack twice on the SAME netns. The second apply
+// then collides at the kernel level (e.g. htb.change rejects because the
+// first apply already installed active classes at handle 1:).
+//
+// The tracker gives us a per-netns claim: the first Start on a netns is
+// "primary" and applies the attack; subsequent Starts on the same netns are
+// "shadow" and no-op. Stop mirrors that decision — the primary reverts,
+// shadows no-op — using the IsShadow flag persisted on NetworkActionState.
+//
+// The in-memory counter here only coordinates concurrent Start calls within
+// a single extension-container process. IsShadow lives on state, so Stop
+// still does the right thing after an extension pod restart.
+//
+// Restart caveat: if the extension pod restarts *between* the primary's
+// Start (already applied) and a shadow's Start (hasn't run yet), the
+// tracker resets to empty; the shadow's Start then thinks it's the primary
+// and tries to apply, which will collide with the primary's still-installed
+// tc rules. This is a rare race — usually all Starts for one experiment
+// arrive within the same second — and the collision surfaces as a normal
+// Apply error the platform can retry. Persisting the tracker to disk to
+// close the race isn't worth the complexity today.
+var netnsAttackTracker = struct {
+	sync.Mutex
+	active map[string]int
+}{active: map[string]int{}}
+
+// netNsID returns the tracker key for a target process's network namespace.
+// Matches the format used by netfault's runcRunner.id() so both layers key
+// by the same identifier — inode preferred (immutable and unique per
+// namespace instance on a single kernel), path as fallback for cases where
+// the caller didn't populate the inode.
+func netNsID(process ociruntime.LinuxProcessInfo) string {
+	for _, ns := range process.Namespaces {
+		if ns.Type == specs.NetworkNamespace {
+			if ns.Inode != 0 {
+				return strconv.FormatUint(ns.Inode, 10)
+			}
+			return ns.Path
+		}
+	}
+	return ""
+}
+
+// claimNetnsForAttack increments the netns counter and reports whether this
+// caller is the first (should apply the attack). Later callers on the same
+// netns receive false (should skip apply and mark themselves as shadow).
+// Empty id short-circuits to true so an unknown-netns target still applies
+// — safer than silently no-op'ing.
+func claimNetnsForAttack(id string) bool {
+	if id == "" {
+		return true
+	}
+	netnsAttackTracker.Lock()
+	defer netnsAttackTracker.Unlock()
+	first := netnsAttackTracker.active[id] == 0
+	netnsAttackTracker.active[id]++
+	return first
+}
+
+// releaseNetnsForAttack decrements the netns counter after a Stop. The
+// return value isn't used by the current call sites (Stop consults
+// NetworkActionState.IsShadow to decide whether to revert), but keeping it
+// symmetric with claim makes future refcount-based decisions straightforward.
+// Idempotent when the tracker doesn't know about this netns (e.g. after a
+// restart wiped the in-memory state).
+func releaseNetnsForAttack(id string) {
+	if id == "" {
+		return
+	}
+	netnsAttackTracker.Lock()
+	defer netnsAttackTracker.Unlock()
+	n := netnsAttackTracker.active[id]
+	if n <= 1 {
+		delete(netnsAttackTracker.active, id)
+		return
+	}
+	netnsAttackTracker.active[id] = n - 1
+}

--- a/extcontainer/netns_dedup_test.go
+++ b/extcontainer/netns_dedup_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 steadybit GmbH. All rights reserved.
+
+package extcontainer
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/steadybit/action-kit/go/action_kit_commons/ociruntime"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestClaimAndRelease_FirstIsPrimary_SubsequentAreShadow locks down the core
+// dedup contract: first Start on a netns applies, later Starts on the same
+// netns become shadows, and after everyone releases the netns is claimable
+// again from scratch (so a fresh attack cycle re-runs primary/shadow logic
+// correctly).
+func TestClaimAndRelease_FirstIsPrimary_SubsequentAreShadow(t *testing.T) {
+	const id = "test-netns-1001"
+	// Belt-and-braces: reset any state a parallel test may have leaked.
+	t.Cleanup(func() { releaseNetnsForAttack(id); releaseNetnsForAttack(id) })
+
+	assert.True(t, claimNetnsForAttack(id), "first claim is primary")
+	assert.False(t, claimNetnsForAttack(id), "second claim on same netns is shadow")
+	assert.False(t, claimNetnsForAttack(id), "third claim on same netns is shadow")
+
+	releaseNetnsForAttack(id)
+	releaseNetnsForAttack(id)
+	releaseNetnsForAttack(id)
+
+	assert.True(t, claimNetnsForAttack(id), "fully released netns claims fresh as primary again")
+	t.Cleanup(func() { releaseNetnsForAttack(id) })
+}
+
+// TestClaim_DifferentNetnsAreIndependent verifies containers on different
+// pods (different netns) never see each other — each is its own primary.
+func TestClaim_DifferentNetnsAreIndependent(t *testing.T) {
+	assert.True(t, claimNetnsForAttack("netns-a"))
+	assert.True(t, claimNetnsForAttack("netns-b"))
+	t.Cleanup(func() { releaseNetnsForAttack("netns-a"); releaseNetnsForAttack("netns-b") })
+}
+
+// TestClaim_EmptyIDShortCircuits guards against an unknown-netns target
+// silently becoming a shadow. Empty ID means we couldn't identify the
+// namespace at all; safer to apply than to no-op.
+func TestClaim_EmptyIDShortCircuits(t *testing.T) {
+	assert.True(t, claimNetnsForAttack(""), "empty netns id always claims (safer than silent shadow)")
+	assert.True(t, claimNetnsForAttack(""), "second empty-id claim is also allowed — they're not shared state")
+}
+
+// TestClaim_ConcurrentReturnsExactlyOnePrimary exercises the mutex under
+// contention: 32 goroutines racing on the same netns id — exactly one gets
+// `true`, everyone else gets `false`. Regression guard for anyone
+// refactoring the tracker without preserving atomicity.
+func TestClaim_ConcurrentReturnsExactlyOnePrimary(t *testing.T) {
+	const id = "test-netns-concurrent"
+	const workers = 32
+	t.Cleanup(func() {
+		for i := 0; i < workers; i++ {
+			releaseNetnsForAttack(id)
+		}
+	})
+
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		primaries int
+	)
+	start := make(chan struct{})
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if claimNetnsForAttack(id) {
+				mu.Lock()
+				primaries++
+				mu.Unlock()
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, 1, primaries, "exactly one goroutine may claim the netns as primary")
+}
+
+// TestNetNsID_PrefersInode confirms netNsID uses the inode (immutable and
+// unique per-namespace-instance) when available. This matches
+// netfault.runcRunner.id() so both layers key by the same value.
+func TestNetNsID_PrefersInode(t *testing.T) {
+	p := ociruntime.LinuxProcessInfo{
+		Namespaces: []ociruntime.LinuxNamespace{
+			{Type: specs.MountNamespace, Path: "/proc/12345/ns/mnt", Inode: 4026531840},
+			{Type: specs.NetworkNamespace, Path: "/proc/12345/ns/net", Inode: 4026531993},
+		},
+	}
+	assert.Equal(t, "4026531993", netNsID(p), "inode wins over path")
+}
+
+// TestNetNsID_FallsBackToPath covers the case where Inode wasn't populated
+// (rare, but LinuxProcessInfo permits it) — we still return a stable key
+// so the tracker works.
+func TestNetNsID_FallsBackToPath(t *testing.T) {
+	p := ociruntime.LinuxProcessInfo{
+		Namespaces: []ociruntime.LinuxNamespace{
+			{Type: specs.NetworkNamespace, Path: "/proc/12345/ns/net"},
+		},
+	}
+	assert.Equal(t, "/proc/12345/ns/net", netNsID(p))
+}
+
+// TestNetNsID_NoNetworkNamespaceReturnsEmpty documents that a target
+// without a network namespace produces an empty id. Combined with the
+// empty-id short-circuit in claimNetnsForAttack that keeps such targets
+// from silently becoming shadows.
+func TestNetNsID_NoNetworkNamespaceReturnsEmpty(t *testing.T) {
+	p := ociruntime.LinuxProcessInfo{
+		Namespaces: []ociruntime.LinuxNamespace{
+			{Type: specs.MountNamespace, Path: "/proc/12345/ns/mnt", Inode: 42},
+		},
+	}
+	assert.Empty(t, netNsID(p))
+}

--- a/extcontainer/netns_dedup_test.go
+++ b/extcontainer/netns_dedup_test.go
@@ -3,6 +3,7 @@
 package extcontainer
 
 import (
+	"encoding/json"
 	"sync"
 	"testing"
 
@@ -11,61 +12,110 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestClaimAndRelease_FirstIsPrimary_SubsequentAreShadow locks down the core
-// dedup contract: first Start on a netns applies, later Starts on the same
-// netns become shadows, and after everyone releases the netns is claimable
-// again from scratch (so a fresh attack cycle re-runs primary/shadow logic
-// correctly).
-func TestClaimAndRelease_FirstIsPrimary_SubsequentAreShadow(t *testing.T) {
+func fullyRelease(id string) {
+	for {
+		netnsAttackTracker.Lock()
+		_, exists := netnsAttackTracker.active[id]
+		netnsAttackTracker.Unlock()
+		if !exists {
+			return
+		}
+		releaseNetnsForAttack(id)
+	}
+}
+
+// TestClaimAndRelease_PrimaryThenShadowThenReleaseCycle locks down the core
+// dedup contract for the bug this fix addresses: first Start on a netns is
+// primary, later Starts with IDENTICAL opts become shadows, and after
+// everyone releases the netns is claimable again from scratch (so a fresh
+// experiment reruns the primary/shadow logic correctly).
+func TestClaimAndRelease_PrimaryThenShadowThenReleaseCycle(t *testing.T) {
 	const id = "test-netns-1001"
-	// Belt-and-braces: reset any state a parallel test may have leaked.
-	t.Cleanup(func() { releaseNetnsForAttack(id); releaseNetnsForAttack(id) })
+	opts := json.RawMessage(`{"bandwidth":"1mbit","filter":{"include":["10.0.0.0/8"]}}`)
+	t.Cleanup(func() { fullyRelease(id) })
 
-	assert.True(t, claimNetnsForAttack(id), "first claim is primary")
-	assert.False(t, claimNetnsForAttack(id), "second claim on same netns is shadow")
-	assert.False(t, claimNetnsForAttack(id), "third claim on same netns is shadow")
+	assert.Equal(t, ClaimPrimary, claimNetnsForAttack(id, opts), "first claim is primary")
+	assert.Equal(t, ClaimShadow, claimNetnsForAttack(id, opts), "second identical claim is shadow")
+	assert.Equal(t, ClaimShadow, claimNetnsForAttack(id, opts), "third identical claim is shadow")
 
 	releaseNetnsForAttack(id)
 	releaseNetnsForAttack(id)
 	releaseNetnsForAttack(id)
 
-	assert.True(t, claimNetnsForAttack(id), "fully released netns claims fresh as primary again")
-	t.Cleanup(func() { releaseNetnsForAttack(id) })
+	assert.Equal(t, ClaimPrimary, claimNetnsForAttack(id, opts), "fully released netns claims fresh as primary again")
+}
+
+// TestClaim_DifferentOptsPassThrough is the fix for Claude review finding
+// #2: a sibling container running a DIFFERENT attack on the same netns
+// must not be silently shadowed — it must pass through to netfault so the
+// user-visible conflict error is preserved for combined attacks.
+func TestClaim_DifferentOptsPassThrough(t *testing.T) {
+	const id = "test-netns-different-opts"
+	optsA := json.RawMessage(`{"bandwidth":"1mbit"}`)
+	optsB := json.RawMessage(`{"corruption":10}`) // different attack shape entirely
+	t.Cleanup(func() { fullyRelease(id) })
+
+	assert.Equal(t, ClaimPrimary, claimNetnsForAttack(id, optsA))
+	assert.Equal(t, ClaimPassthrough, claimNetnsForAttack(id, optsB), "different opts must pass through, not shadow")
+	assert.Equal(t, ClaimShadow, claimNetnsForAttack(id, optsA), "identical opts still shadow even after a passthrough")
+}
+
+// TestClaim_PassthroughDoesNotTouchCounter guarantees passthroughs don't
+// affect the ref-count. If a passthrough incremented it, a later
+// Stop-of-primary wouldn't tear the counter back to zero and the netns
+// would stay stuck in an "already claimed" state — exactly the leak
+// pathology finding #1 flagged.
+func TestClaim_PassthroughDoesNotTouchCounter(t *testing.T) {
+	const id = "test-netns-passthrough-noop"
+	optsA := json.RawMessage(`{"delay":100}`)
+	optsB := json.RawMessage(`{"loss":50}`)
+	t.Cleanup(func() { fullyRelease(id) })
+
+	assert.Equal(t, ClaimPrimary, claimNetnsForAttack(id, optsA))
+	assert.Equal(t, ClaimPassthrough, claimNetnsForAttack(id, optsB))
+	assert.Equal(t, ClaimPassthrough, claimNetnsForAttack(id, optsB))
+
+	// Only one release should be needed for primary — passthroughs don't
+	// hold a counter. After it, the netns should be free.
+	releaseNetnsForAttack(id)
+	assert.Equal(t, ClaimPrimary, claimNetnsForAttack(id, optsB), "netns free again after single release; passthroughs didn't leak counter")
 }
 
 // TestClaim_DifferentNetnsAreIndependent verifies containers on different
 // pods (different netns) never see each other — each is its own primary.
 func TestClaim_DifferentNetnsAreIndependent(t *testing.T) {
-	assert.True(t, claimNetnsForAttack("netns-a"))
-	assert.True(t, claimNetnsForAttack("netns-b"))
-	t.Cleanup(func() { releaseNetnsForAttack("netns-a"); releaseNetnsForAttack("netns-b") })
+	opts := json.RawMessage(`{}`)
+	t.Cleanup(func() { fullyRelease("netns-a"); fullyRelease("netns-b") })
+
+	assert.Equal(t, ClaimPrimary, claimNetnsForAttack("netns-a", opts))
+	assert.Equal(t, ClaimPrimary, claimNetnsForAttack("netns-b", opts))
 }
 
 // TestClaim_EmptyIDShortCircuits guards against an unknown-netns target
 // silently becoming a shadow. Empty ID means we couldn't identify the
 // namespace at all; safer to apply than to no-op.
 func TestClaim_EmptyIDShortCircuits(t *testing.T) {
-	assert.True(t, claimNetnsForAttack(""), "empty netns id always claims (safer than silent shadow)")
-	assert.True(t, claimNetnsForAttack(""), "second empty-id claim is also allowed — they're not shared state")
+	opts := json.RawMessage(`{}`)
+	assert.Equal(t, ClaimPrimary, claimNetnsForAttack("", opts), "empty netns id always claims (safer than silent shadow)")
+	assert.Equal(t, ClaimPrimary, claimNetnsForAttack("", opts), "second empty-id claim also primary — no shared state")
 }
 
-// TestClaim_ConcurrentReturnsExactlyOnePrimary exercises the mutex under
-// contention: 32 goroutines racing on the same netns id — exactly one gets
-// `true`, everyone else gets `false`. Regression guard for anyone
-// refactoring the tracker without preserving atomicity.
-func TestClaim_ConcurrentReturnsExactlyOnePrimary(t *testing.T) {
+// TestClaim_ConcurrentIdenticalOptsExactlyOnePrimary exercises the mutex
+// under contention: 32 goroutines racing on the same netns id with
+// identical opts — exactly one gets ClaimPrimary, everyone else gets
+// ClaimShadow. Regression guard for anyone refactoring the tracker without
+// preserving atomicity.
+func TestClaim_ConcurrentIdenticalOptsExactlyOnePrimary(t *testing.T) {
 	const id = "test-netns-concurrent"
 	const workers = 32
-	t.Cleanup(func() {
-		for i := 0; i < workers; i++ {
-			releaseNetnsForAttack(id)
-		}
-	})
+	opts := json.RawMessage(`{"bandwidth":"5mbit"}`)
+	t.Cleanup(func() { fullyRelease(id) })
 
 	var (
-		wg       sync.WaitGroup
-		mu       sync.Mutex
+		wg        sync.WaitGroup
+		mu        sync.Mutex
 		primaries int
+		shadows   int
 	)
 	start := make(chan struct{})
 	for i := 0; i < workers; i++ {
@@ -73,9 +123,14 @@ func TestClaim_ConcurrentReturnsExactlyOnePrimary(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			if claimNetnsForAttack(id) {
+			switch claimNetnsForAttack(id, opts) {
+			case ClaimPrimary:
 				mu.Lock()
 				primaries++
+				mu.Unlock()
+			case ClaimShadow:
+				mu.Lock()
+				shadows++
 				mu.Unlock()
 			}
 		}()
@@ -84,6 +139,18 @@ func TestClaim_ConcurrentReturnsExactlyOnePrimary(t *testing.T) {
 	wg.Wait()
 
 	assert.Equal(t, 1, primaries, "exactly one goroutine may claim the netns as primary")
+	assert.Equal(t, workers-1, shadows, "every other goroutine sees identical opts and becomes shadow")
+}
+
+// TestRelease_IsIdempotentWhenTrackerForgot documents that releasing a
+// netns the tracker doesn't know about (e.g. after an extension restart
+// wiped the in-memory state) is a safe no-op — Stop can call this without
+// having to check whether the tracker still remembers.
+func TestRelease_IsIdempotentWhenTrackerForgot(t *testing.T) {
+	assert.NotPanics(t, func() {
+		releaseNetnsForAttack("test-netns-never-claimed")
+		releaseNetnsForAttack("")
+	})
 }
 
 // TestNetNsID_PrefersInode confirms netNsID uses the inode (immutable and


### PR DESCRIPTION
## Summary

Fixes a customer-reported bug on `demo-develop-demo` where a container network attack (Limit Bandwidth) fails with:

```
Failed to apply network settings.: Command failed tc -force -batch -
Error: Change operation not supported by specified qdisc.
Command failed -:1
```

## Root cause

Two `prepare` requests hit extension-container 1ms apart, both targeting the **same netns** (`4026533190`) — the classic Kubernetes case of multiple containers sharing their pod's network namespace. Extension-container fired an apply per container; the platform doesn't know they share a netns.

Both applies got past `netfault.pushActiveNetfault` because `LimitBandwidthOpts.doesConflictWith` returns `false` when two attacks have identical `Bandwidth`, `Filter`, and `Interfaces` — they're "compatible", not "conflicting". Netfault currently isn't idempotent at the tc level though, so the second apply then does `tc qdisc replace dev eth0 root handle 1: htb default 30` on top of the already-installed htb, which the kernel converts to `htb.change` and rejects because active classes exist.

Extension-container logs confirmed this exactly — two `captured qdisc snapshot` entries for netns `4026533190` 53ms apart, first showing clean `noqueue 0:0 dev eth0 root`, second showing the fully-installed htb tree the first apply had just created.

## Fix (extension-container-layer dedup)

- **New `extcontainer/netns_dedup.go`** — per-process in-memory netns tracker keyed by netns inode. First Start on a netns claims it as **primary** and applies the attack; subsequent Starts on the same netns become **shadow** and no-op with a clear message on the result.
- **`IsShadow` on `NetworkActionState`** — persisted via `action_kit_sdk` state so Stop mirrors the same decision: primary reverts, shadow no-ops. The split survives an extension pod restart between Start and Stop.
- Empty netns id short-circuits to primary (safer than a silent shadow when the target's netns can't be identified).
- If Apply fails, the primary releases its claim so a sibling container can retry.

## Restart-race caveat (documented in-code)

If the extension pod restarts **between** the primary's already-applied Start and a shadow's not-yet-run Start, the in-memory tracker resets to empty and the shadow's Start will think it's primary — colliding with the still-installed tc rules. This is rare (Start calls typically arrive within the same second), the collision surfaces as a normal Apply error the platform can retry, and persisting the tracker to disk isn't worth the complexity today.

## Tests

`extcontainer/netns_dedup_test.go` — 7 unit tests:
- First-claim-is-primary, subsequent-are-shadow, re-claim after full release
- Different netns IDs are independent  
- Empty netns ID short-circuits to primary
- 32-goroutine concurrent claim → exactly one primary (mutex regression guard)
- `netNsID` prefers inode over path (matches `netfault.runcRunner.id()`)
- Path fallback when inode is 0
- Empty result when target has no network namespace

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./extcontainer/... -count=1` passes (existing + 7 new)
- [ ] Deploy to demo-develop-demo, rerun the Limit Bandwidth experiment on the multi-container pod → primary applies, shadow no-ops, no `Change operation not supported` error
- [ ] Confirm host qdisc tree still restores byte-identically on Stop (existing snapshot/restore path unchanged for the primary)