### PR TITLE
chore: update dns-inject to v0.2.3

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ builds:
       - CGO_ENABLED=0
       - MEMFILL_VERSION=v1.3.1
       - NSMOUNT_VERSION=v1.1.1
-      - DNS_INJECT_VERSION=v0.2.2
+      - DNS_INJECT_VERSION=v0.2.3
     goos:
       - linux
     goarch:


### PR DESCRIPTION
Update dns-inject from v0.2.2 to v0.2.3 in the GoReleaser config.