### PR TITLE
build: run e2e tests on ARM self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   e2e-tests:
     name: E2E Tests (${{ matrix.e2e-runtime }})
-    runs-on: steadybit_runner_ubuntu_latest_4cores_16GB
+    runs-on: steadybit_runner_ubuntu_latest_4cores_16GB_ARM
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -2037,7 +2037,7 @@ func testStressCombined(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
 	err := nginx.Deploy("nginx-stress-combined", func(p *acorev1.PodApplyConfiguration) {
 		p.Spec.Containers[0].Resources = &acorev1.ResourceRequirementsApplyConfiguration{
 			Limits: &corev1.ResourceList{
-				"memory": resource.MustParse("250Mi"),
+				"memory": resource.MustParse("512Mi"),
 			},
 		}
 	})


### PR DESCRIPTION
Switches the E2E test matrix (`docker`, `containerd`, `cri-o`) from the x64 `steadybit_runner_ubuntu_latest_4cores_16GB` runner to the ARM equivalent `steadybit_runner_ubuntu_latest_4cores_16GB_ARM` (already in use by integration-tests) to reduce cost.

Also validates the container extension on arm64.