### PR TITLE
chore: run e2e tests on free ubuntu-latest runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   e2e-tests:
     name: E2E Tests (${{ matrix.e2e-runtime }})
-    runs-on: steadybit_runner_ubuntu_latest_4cores_16GB_ARM
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What
Switch the `e2e-tests` matrix (docker/containerd/cri-o) from the billed larger runner `steadybit_runner_ubuntu_latest_4cores_16GB_ARM` to the standard **`ubuntu-latest`** runner.

## Why
This is a **public** repo, where the standard runner is 4 vCPU / 16 GB and standard-runner minutes are **free/unlimited**. This was the single biggest "Actions Linux 4-core" spender (~$118 YTD); the standard runner has the same specs at $0.

## Scope & safety
- Only the `e2e-tests` job is affected; the downstream multi-arch build/release job is untouched.
- The e2e job has no arch-specific logic (checkout, Go, `make e2e-test`), so amd64 vs the previous arm64 runner is behaviourally equivalent.