### PR TITLE
fix: use gcp.zone instead of google.zone as AZ fallback attribute

### DIFF
--- a/extcontainer/discovery.go
+++ b/extcontainer/discovery.go
@@ -69,7 +69,7 @@ func (d *containerDiscovery) DescribeTarget() discovery_kit_api.TargetDescriptio
 				{Attribute: "k8s.pod.name"},
 				{Attribute: "k8s.namespace"},
 				{Attribute: "host.hostname"},
-				{Attribute: "aws.zone", FallbackAttributes: &[]string{"google.zone", "azure.zone"}},
+				{Attribute: "aws.zone", FallbackAttributes: &[]string{"gcp.zone", "azure.zone"}},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{
 				{Attribute: "k8s.container.name", Direction: discovery_kit_api.ASC},


### PR DESCRIPTION
## Summary
- The `aws.zone` target attribute's fallback list referenced `google.zone`, but no extension ever sets that attribute — GCP zone data is published as `gcp.zone` (see extension-gcp, extension-gatling, extension-http, extension-jmeter, extension-k6). Fixes the fallback so it actually resolves on GCP hosts.

Related to BM #22908.

## Test plan
- [x] `go build ./...`
- [x] `go test ./extcontainer/...`